### PR TITLE
fix(story/NEXT-999): Email transactionnel - Confirmation de commande envoyée en double

### DIFF
--- a/src/Controller/IpnController.php
+++ b/src/Controller/IpnController.php
@@ -154,12 +154,12 @@ final class IpnController
             $this->orderPaymentStateResolver->resolve($order);
         }
 
-        $paymentStateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
-
         $stateMachine = $this->factory->get($order, OrderCheckoutTransitions::GRAPH);
         if ($stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE)) {
             $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
         }
+
+        $paymentStateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
 
         return 'SUCCESS';
     }
@@ -228,7 +228,7 @@ final class IpnController
 
                 $this->em->flush();
             }
-            
+
             return new Response($content);
         }
 


### PR DESCRIPTION
Application de la transition `OrderCheckoutTransitions::TRANSITION_COMPLETE` sur l'order avant l'application de transition `PaymentTransitions::TRANSITION_COMPLETE` sur l'objet payment afin d'éviter que ce soit la transition complete qui déclenche en cascade les 2 callback de SM OrderCompletedAndPaid